### PR TITLE
undo call{T}(::Type{Node{T}}, x) deprecation

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -48,8 +48,18 @@ immutable Action
 end
 isrequired(a::Action) = a.recipient.value != nothing && a.recipient.value.alive
 
-Signal{T}(x::T, parents=()) = Signal{T}(x, parents, Action[], true, Dict{Signal, Int}())
-Signal{T}(::Type{T}, x, parents=()) = Signal{T}(x, parents, Action[], true, Dict{Signal, Int}())
+
+function Base.call{T}(::Type{Signal{T}}, x, parents=())
+    Signal{T}(x, parents, Action[], true, Dict{Signal, Int}())
+end
+
+function Signal{T}(x::T, parents=())
+    Signal{T}(x, parents)
+end
+
+function Signal{T}(::Type{T}, x, parents=())
+    Signal{T}(x, parents)
+end
 
 # preserve/unpreserve nodes from gc
 """

--- a/src/deprecation.jl
+++ b/src/deprecation.jl
@@ -10,4 +10,3 @@ export lift, consume, foldl, keepwhen, keepif, dropif, dropwhen
 @deprecate keepif filter
 @deprecate dropif(f, default, signal) filter(x -> !f(x), default, signal)
 @deprecate dropwhen(predicate, x, signal) filterwhen(map(!, predicate), x, signal)
-@deprecate call{T}(::Type{Signal{T}}, x) Signal(T, x)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -13,6 +13,17 @@ facts("Basic checks") do
     a = Signal(number())
     b = map(x -> x*x, a)
 
+    context("constructors") do
+        s1 = Signal{Float64}(1) # convert from int
+        s2 = Signal(1.0)
+        s3 = Signal(Float64, 1)
+        @fact typeof(s1) --> Signal{Float64}
+        @fact typeof(s1) --> typeof(s2)
+        @fact typeof(s2) --> typeof(s3)
+        s4 = Signal{Int}(1.0) # convert from float
+        @fact typeof(s4) --> Signal{Int}
+    end
+
     context("map") do
 
         # Lift type


### PR DESCRIPTION
This undoes the deprecation introduced in #65 for `call{T}(::Type{Node{T}}, x)`. AFAIK it wasn't an issue with syntax as much as the difficulty of finding the right `Base.call` (arggghh type invariance!). 
