### PR TITLE
Use an action queue/set to ensure actions are performed in the correct order and aren't repeated

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+DataStructures

--- a/src/time.jl
+++ b/src/time.jl
@@ -8,7 +8,7 @@ Throttle a signal to update at most once every dt seconds. By default, the throt
 This behavior can be changed by the `f`, `init` and `reinit` arguments. The `init` and `f` functions are similar to `init` and `f` in `foldp`. `reinit` is called when a new throttle time window opens to reinitialize the initial value for accumulation, it gets one argument, the previous accumulated value.
 
 For example
-    y = throttle(0.2, x, push!, Int[], _->Int[])
+    `y = throttle(0.2, x, push!, Int[], _->Int[])`
 will create vectors of updates to the integer signal `x` which occur within 0.2 second time windows.
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -61,7 +61,7 @@ facts("Basic checks") do
         push!(a, number())
         step()
         # precedence to b over a -- a is older.
-        @fact value(e) --> value(a)
+        @fact value(e) --> value(b)
 
         c = map(_->_, a) # Make a younger than b
         f = merge(d, c, b)
@@ -73,6 +73,7 @@ facts("Basic checks") do
     context("foldp") do
 
         ## foldl over time
+        gc()
         push!(a, 0)
         step()
         f = foldp(+, 0, a)

--- a/test/call_count.jl
+++ b/test/call_count.jl
@@ -35,3 +35,40 @@ facts("Call counting") do
         @fact cf.value --> 2i
     end
 end
+
+facts("multi-path graphs") do
+    a = Signal(0)
+    b = Signal(0)
+
+    c = map(+, a, b)
+    d = merge(a, b)
+    e = map(+, a, map(x->2x, a)) # Both depend on a
+    f = map(+, a, b, c, e)
+
+    for (av,bv) in [(1,2),(1,3),(7,7)]
+        push!(a, av)
+        push!(b, bv-1)
+        Reactive.run_till_now()
+        push!(b, bv)
+        Reactive.run_till_now()
+        @fact value(c) --> av + bv
+        @fact value(e) --> 3av
+        @fact value(d) --> bv
+        @fact value(f) --> 5av + 2bv
+    end
+
+    xv = 2
+    x = Signal(xv)
+    y = map(identity, x)
+    x2 = map(x->2x, x)
+    z = map(+, y, x2)
+    Reactive.run_till_now()
+    @fact value(y) --> xv
+    @fact value(x2) --> 2xv
+    @fact value(z) --> 3xv
+
+    xv2 = xv + 1
+    push!(x, xv2)
+    Reactive.run_till_now()
+    @fact value(z) --> 3xv2
+end


### PR DESCRIPTION
Instead of performing actions attached to a node as soon as a new value is sent to it, add the actions to an ordered set `action_queue` for the current `push!` message, keyed (de-duplicated) using the recipient node. This ensures that actions that would previously have been performed twice, or performed once before all the inputs to the action had updated (and ignored later after they had all updated due to the `timestep` mechanism), will be performed once and at the correct time, i.e. after all their inputs have updated for this `push!` message.

Essentially causes the Signal graph to be traversed breadth first, rather than the previous depth first.

Fixes #101