### PR TITLE
Turn on precompilation

### DIFF
--- a/src/Reactive.jl
+++ b/src/Reactive.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Reactive
 
 include("core.jl")


### PR DESCRIPTION
I don't see any reason why precompilation shouldn't work for Reactive.jl, and not having it here blocks precompilation in any modules that depend on Reactive. Is there any reason it isn't currently enabled? 