### PR TITLE
fix a bug in unbind! operator

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -297,7 +297,7 @@ function unbind!(a::Signal, b::Signal, twoway=true)
     end
 
     action = _bindings[a=>b]
-    a.actions = filter(x->x!=action, a.actions)
+    b.actions = filter(x->x!=action, b.actions)
     delete!(_bindings, a=>b)
 
     if twoway

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -229,4 +229,22 @@ facts("Basic checks") do
         step()
         @fact value(y) --> 1
     end
+
+
+    context("bindind") do
+        x = Signal(0)
+        y = Signal(0)
+        bind!(y,x,false)
+
+        push!(x,1000)
+        step()
+
+        @fact value(y) --> 1000
+
+        unbind!(y,x,false)
+        push!(x,0)
+        step()
+
+        @fact value(y) --> 1000
+    end
 end


### PR DESCRIPTION
before this fix:
```
julia> a = Signal(1)
Signal{Int64}(1, nactions=0)

julia> b = Signal(10)
Signal{Int64}(10, nactions=0)

julia> bind!(b,a,false)

julia> push!(a,1000)

julia> value(b)
1000

julia> unbind!(b,a,false)

julia> push!(a,0)

julia> value(b)
0
```

afterwards:

```
julia> a = Signal(1)
Signal{Int64}(1, nactions=0)

julia> b = Signal(10)
Signal{Int64}(10, nactions=0)

julia> bind!(b,a,false)

julia> push!(a,1000)

julia> value(b)
1000

julia> unbind!(b,a,false)

julia> push!(a,0)

julia> value(b)
1000
```