### PR TITLE
Allow Signals to be used as `view` indices

### DIFF
--- a/src/Reactive.jl
+++ b/src/Reactive.jl
@@ -6,6 +6,7 @@ include("core.jl")
 include("operators.jl")
 include("async.jl")
 include("time.jl")
+include("arrays.jl")
 
 include("deprecation.jl")
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,0 +1,36 @@
+# Use Signals as indices for arrays
+
+export freeze
+
+using Base: ViewIndex, tail, to_indexes, to_index, index_shape
+typealias RangeCheckedSignal{T,B<:Range} CheckedSignal{T,B}
+
+##### Array overrides #####
+
+Base.to_index(s::CheckedSignal) = to_index(value(s))
+
+function Base.view{T,N}(A::AbstractArray{T,N}, I::Vararg{Union{ViewIndex,RangeCheckedSignal},N})
+    B = map(bounds, I)
+    checkbounds(A, B...)
+    J = to_indexes(I...)
+    SubArray(A, I, map(length, index_shape(A, J...)))
+end
+
+@inline function Base._indices_sub(S::SubArray, pinds, s::RangeCheckedSignal, I...)
+    i = to_index(s)
+    Base._indices_sub(S, pinds, i, I...)
+end
+
+@inline Base.reindex(V, idxs::Tuple{RangeCheckedSignal, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) =
+    Base.reindex(V, (to_index(idxs[1]), tail(idxs)...), subidxs)
+
+"""
+    freeze(V::SubArray) -> Vnew
+
+Return a new SubArray equivalent to `V` at the time of the `freeze`
+call. If `V` has `Signal` indices, they will be converted to static
+indices. `Vnew` can be useful if you need to ensure that
+signal-indices won't update in the middle of some operation that
+`yield`s.
+"""
+@inline freeze(V::SubArray) = view(parent(V), Base.to_indexes(V.indexes...)...)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck 0.3.0
+OffsetArrays

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -1,0 +1,50 @@
+using Reactive, OffsetArrays
+using Base.Test
+
+@testset "Indices" begin
+    @testset "Scalar indexing" begin
+        A = reshape(1:3*4*2, 3, 4, 2)
+        s = CheckedSignal(1, 1:2)
+        V = view(A, :, :, s)
+        @test V == reshape(1:12, 3, 4)
+        push!(s, 2)
+        step()
+        @test V == reshape(13:24, 3, 4)
+        @test freeze(V) == reshape(13:24, 3, 4)
+
+        s = CheckedSignal(1, 1:3)
+        @test_throws BoundsError view(A, :, :, s)
+
+        V = view(A, s, :, :)
+        @test V == A[1,:,:]
+        push!(s, 3)
+        step()
+        @test V == A[3,:,:]
+
+        V = view(A, :, s, :)
+        @test V == A[:, 3, :]
+    end
+
+    @testset "Vector indexing" begin
+        A = reshape(1:3*4*2, 3, 4, 2)
+        s = CheckedSignal(1:4, 1:4)
+        V = view(A, :, s, :)
+        @test V == A
+        push!(s, 2:3)
+        step()
+        @test V == A[:, 2:3, :]
+    end
+
+    @testset "Offset indexing" begin
+        A = OffsetArray(reshape(1:3*4*2, 3, 4, 2), 1:3, 1:4, 1:2)
+        s = CheckedSignal(OffsetArray(1:4, 1:4), 1:4)
+        V = view(A, :, s, :)
+        @test V == A
+        push!(s, OffsetArray(2:3, 2:3))
+        step()
+        @test indices(V) === (1:3, 2:3, 1:2)
+        @test V == A[:, OffsetArray(2:3, 2:3), :]
+    end
+end
+
+nothing

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -1,0 +1,30 @@
+using Reactive, Base.Test
+
+@testset "CheckedSignal" begin
+    @test_throws ArgumentError CheckedSignal(0, 1:2)
+    @test_throws ArgumentError CheckedSignal(3, 1:2)
+    @test_throws ArgumentError CheckedSignal(1, 2:3)
+    @test value(CheckedSignal(2, 2:3)) == 2
+    s = @inferred(CheckedSignal(1, 1:2))
+    ms = map(x->x-100, s)
+    @test value(ms) == -99
+    push!(s, 2)
+    step()
+    @test value(s) == 2
+    @test value(ms) == -98
+    @test_throws ArgumentError push!(s, 3)
+    @test_throws ArgumentError push!(s, 0)
+
+    f(x) = contains(x, "red")
+    s = CheckedSignal("Fred", f)
+    @test value(s) == "Fred"
+    push!(s, "credulous")
+    step()
+    @test value(s) == "credulous"
+    @test_throws ArgumentError push!(s, "read")
+
+    preserve(s)
+    unpreserve(s)
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,3 +17,4 @@ FactCheck.exitstatus()
 
 # Newer Base.Test tests
 include("checked.jl")
+include("arrays.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,3 +14,6 @@ include("flatten.jl")
 include("time.jl")
 include("async.jl")
 FactCheck.exitstatus()
+
+# Newer Base.Test tests
+include("checked.jl")


### PR DESCRIPTION
This one is one of those "boy, julia sure is fun" changes. The motivation for this was to support a more flexible approach to "movie player" GUIs. I've written 3 separate player GUIs over my career, and I've never been happy with how important information gets "buried" inside the visualization code (which makes it hard to extend). For example:
- what if you have *two* images, and you want the play button/slider to keep the two movies in sync? 
- what if the user wants to compute the image's mean intensity over the current zoom region?

All this involves getting information *out* of the GUI. What I finally realized is that perhaps the better strategy is to inject the necessary information *into* the GUI...or rather, the data itself. A small demo:
```julia
julia> using Reactive

julia> A = reshape(1:3*4*2, 3, 4, 2)
3×4×2 Base.ReshapedArray{Int64,3,UnitRange{Int64},Tuple{}}:
[:, :, 1] =
 1  4  7  10
 2  5  8  11
 3  6  9  12

[:, :, 2] =
 13  16  19  22
 14  17  20  23
 15  18  21  24

julia> s = CheckedSignal(1, 1:2)
Reactive.CheckedSignal{Int64,UnitRange{Int64}}(Signal{Int64}(1, nactions=0),1:2)

julia> V = view(A, :, :, s)
3×4 SubArray{Int64,2,Base.ReshapedArray{Int64,3,UnitRange{Int64},Tuple{}},Tuple{Colon,Colon,Reactive.CheckedSignal{Int64,UnitRange{Int64}}},false}:
 1  4  7  10
 2  5  8  11
 3  6  9  12

julia> push!(s, 2)

julia> V
3×4 SubArray{Int64,2,Base.ReshapedArray{Int64,3,UnitRange{Int64},Tuple{}},Tuple{Colon,Colon,Reactive.CheckedSignal{Int64,UnitRange{Int64}}},false}:
 13  16  19  22
 14  17  20  23
 15  18  21  24
```
With this, you implement a movie player as a dumb 2d image viewer, and provide a controller GUI whose only role is to modifiy `s`. This keeps the two aspects of the GUI orthogonal, and so it's easy to do more complicated stuff. For example, if you use the same `s` in two arrays, you keep two movies in sync; if you use `zoomy, zoomx = CheckedSignal(1, indices(img,1)), CheckedSignal(1, indices(img,2))` and `imgz = view(img, zoomy, zoomx)` then you can "access" the same data being shown in the viewer through `imgz`.

What's also nice is that the performance isn't terrible:
```julia
julia> function mysum(A)
           accum = zero(eltype(A))
           for i in CartesianRange(indices(A))
               accum += A[i]
           end
           accum
       end
mysum (generic function with 1 method)

julia> A = rand(1000,1000,3);

julia> s
Reactive.CheckedSignal{Int64,UnitRange{Int64}}(Signal{Int64}(2, nactions=0),1:2)

julia> V = view(A, :, :, s);

julia> V1 = freeze(V);  # constructs a "regular" view

julia> mysum(V)
499977.50044777873

julia> mysum(V1)
499977.50044777873

julia> @time mysum(V)
  0.003886 seconds (5 allocations: 176 bytes)
499977.50044777873

julia> @time mysum(V1)
  0.002645 seconds (5 allocations: 176 bytes)
499977.50044777873
```

In terms of implementation, I'm aware of the fact that you could make a value-checked signal via `map` on an existing signal or two. But for the purposes of the array code I really wanted to be able to use the type system to ensure that bounds-checking was activated. So in the end I decided to create a new type. If you object to the complexity (I know @shashi worked hard to slim down the number of types), we should discuss whether there are good alternatives.

It's also nice that it only took 13 lines of code to pull off the necessary array changes. Julia is fun. :smile:

CC @Cody-G, @SimonDanisch, @mbauman.