### PR TITLE
Node Creation Order Redesign

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+v0.4.1
+------
+* Fix bugs in signal update ordering - see test/node_order.jl ("bfs bad", and "bfs bad, dfs bad") for examples fixed
+* Fix for #123 changes the behaviour of `throttle`, for the old behaviour, use `debounce`
+* Adds `bound_srcs(dest)`, and `bound_dests(src)` which return signals bound using `bind!(dest, src)`
+* Performance improvements
+
+v0.4.0
+------
+* API for `onerror` changed, see `?push!` for details`
+
 v0.1.8
 ------
 * Mix in Timing module into Reactive and remove it
+

--- a/benchmark/ReactBench.jl
+++ b/benchmark/ReactBench.jl
@@ -1,0 +1,87 @@
+using Reactive, GLAbstraction, GeometryTypes
+import Reactive: edges, nodes
+# Base.step() = Reactive.run(1)
+Reactive.stop()
+
+function test1(; use_async = true)
+    # Reactive.run_async(use_async)
+    a = Signal(0.0)
+
+    b = map(/, a, Signal(23.0))
+    c = map(/, a, Signal(8.0))
+    f = foldp(+, 0.0, b)
+
+    d = map(Vec3f0, b)
+    e = map(Vec3f0, c)
+    g = map(Vec3f0, f)
+
+    m = map(translationmatrix, d)
+    m2 = map(translationmatrix, e)
+
+    m3 = map(*, m, m2)
+    # I don't know why, but Mat*Vec is broken right now
+    result = map(m3, g) do a, b
+         r = a * Vec4f0(b, 1)
+         Vec3f0(r[1], r[2], r[3])
+    end
+    total_time = 0.0
+
+    # warm the cache
+    push!(a, 0.1) # note causes the result to be slightly different, noticable for small N
+    Reactive.run_till_now()
+    println("post warmup, length(nodes): ", length(nodes))
+
+    for i=1:N
+        tic()
+        push!(a, i)
+        Reactive.run(1) # only needed for async
+        total_time += toq()
+    end
+
+    @show(total_time)
+    @show(total_time/N)
+    value(result), total_time
+end
+
+function bf(a,c)
+    a/c
+end
+
+function test2()
+    total_time = 0.0
+    a = 0.0
+    accum = 0.0
+    function ff(x)
+        accum += x
+    end
+    local result
+    for i=1:N
+        tic()
+
+        a = i
+        b = bf(a, 23.0)
+        c = bf(a, 8.0)
+        f = ff(b)
+        d = Vec3f0(b)
+        e = Vec3f0(c)
+        g = Vec3f0(f)
+
+        m = translationmatrix(d)
+        m2 = translationmatrix(e)
+
+        m3 = m*m2
+        r = m3 * Vec4f0(g, 1)
+        result = Vec3f0(r[1], r[2], r[3])
+        total_time += toq()
+    end
+
+    @show(total_time)
+    @show(total_time/N)
+    result, total_time
+end
+
+N = 10^6
+react_res, react_time = test1(use_async=true)
+regular_res, regular_time = test2()
+@show react_res regular_res
+react_time/regular_time

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,46 @@
+using PkgBenchmark
+using Reactive
+
+Reactive.stop()
+
+@benchgroup "Signal creation" begin
+    @bench "int" Signal(0)
+    @bench "string" Signal($("x"))
+    @bench "standalone update" (push!($(Signal(0)), 1); Reactive.run_till_now())
+end
+
+@benchgroup "map 1" begin
+    x = Signal(0)
+    y = map(-, x)
+    @bench "2 node" (push!($x, 1); Reactive.run_till_now())
+
+    z = map(+, x)
+
+    @bench "3 nodes" (push!($x, 1); Reactive.run_till_now())
+
+    a = map(+, x, y)
+    @bench "4 nodes" (push!($x, 1); Reactive.run_till_now())
+end
+
+@benchgroup "map 2" begin
+    a = Signal(0.0)
+
+    b = map(/, a, Signal(23.0))
+    c = map(/, a, Signal(8.0))
+    f = foldp(+, 0.0, b)
+
+    d = map(Vec3f0, b)
+    e = map(Vec3f0, c)
+    g = map(Vec3f0, f)
+
+    m = map(translationmatrix, d)
+    m2 = map(translationmatrix, e)
+
+    m3 = map(*, m, m2)
+    # I don't know why, but Mat*Vec is broken right now
+    result = map(m3, g) do a, b
+         r = a * Vec4f0(b, 1)
+         Vec3f0(r[1], r[2], r[3])
+    end
+    @bench "10 nodes" (push!($x, 1); Reactive.run_till_now())
+end

--- a/doc/Design Overview.md
+++ b/doc/Design Overview.md
@@ -1,0 +1,41 @@
+### Node Creation Order Design
+
+When a node is `push!`ed to in user code, this library must process it and ensure signal values stay consistent with the operations users used to define the chain of signals (e.g. map, foldp, etc.).
+
+(N.b. "node" and "Signal" are used interchangeably in this doc and the code)
+
+The design assumes:
+
+1. The order which nodes are created is a correct [topological ordering](https://en.wikipedia.org/wiki/Topological_ordering) (with the edges of the signal graph  regarded as directed from parents to children)
+2. Signals will end up in a correct state if the order in which each node is processed and their update actions (e.g. the mapped function in the case of a map) run, is the same as the order in which nodes were created.
+3. Signal actions should be run for a given `push!` only if the node itself was pushed to or if one of their parents had their actions run.
+
+This should ensure that parents of nodes update before their children, and signal values will be in a correct state after each `push!` has been processed.
+
+#### Basics
+
+Each node (`Signal`) is added to the end of a Vector called `nodes` on creation, so that `nodes` holds Signals in the order they were created.
+
+Each Signal holds a field `actions` which are just 0-argument functions that update the value of the node or perform some helper function to that end. In some cases the action will update, push to, or set a Timer to update a different node.
+
+Each Signal also has a field `active` which flags whether or not the node was `push!`ed to, or had/should have its actions run, in processing the current push. In essence it flags whether or not the node's value has been updated, or should be updated.
+
+Nodes that are pushed to will always be set to active, other (downstream) nodes will be set to active, and their actions run if any of their parent `Signal`s were active in processing the current `push!`.
+
+On processing each `push!`, we run through `nodes` and execute the actions of each node if it has been set to active, i.e. if it was pushed to, or if any of its parents were active.
+
+#### Pushing to Non Input Nodes
+
+Sometimes it is desirable to push! a value to a non-input node, e.g. a `map` on an input `Signal(...)`, rather than it attaining that value by running its action. In order for this pushed value to "stick", it's important that the map's action does not run after pushing to the node - since the map's action would update the map node to the return value of the function used to create the map, which in general would not be equal to the pushed value.
+
+This is achieved simply by the check in `run_node` requiring an active parent in order to run the node's actions.
+
+A consequence of this is any actions attached to a node with no parents, e.g. an input `Signal(...)` node, will not run. Accordingly, all actions that rely on an update to a node, are attached to a child of the node, and not the node itself. See [dev notes](dev%20notes.md) for more details.
+
+#### Filter
+
+Filter works by setting the filter node's active field to false when the filter condition is false. Downstream/descendent nodes check if at least one of their parents has been active, if none of them have been active then the node will not run its action, thus propagating the filter correctly.
+
+#### More info
+
+There is some info on each operator in the [dev notes](dev%20notes.md). Please feel free to open issues if things are not clear.

--- a/doc/dev notes.md
+++ b/doc/dev notes.md
@@ -1,0 +1,53 @@
+## Developer Notes
+
+### Operators
+
+Action updates the node whose `actions` Vector it's in with `set_value!` (pre-updates, should not run when node is pushed to, i.e. no parents active):
+1. map (multiple parents)
+1. filter (calls deactivate! when f(value(input)) is false)
+1. filterwhen (calls deactivate! when value(input) is false)
+1. foldp (single parent)
+1. sampleon (sample trigger input is its only parent)
+1. merge (multiple parents)
+1. previous (caches the previous update)
+1. droprepeats (calls deactivate! when value(input) == prev_value)
+1. flatten (wire_flatten and set_flatten_val both get run whenever either the `current_node` or the `input` sigsig update. Would it be better to just add those actions to the input and current_node update respectively?)
+
+Action on an auxilliary node connected to the input that pushes to it, this allows the action to run, even if the node is a non-input, but gets pushed to
+1. throttle/debounce (the action is on a foreach on the input node, which sets up a timer to push to the throttle output node)
+1. delay (the action is on a foreach on the input node, which just pushes to the delay node)
+1. bind! (action is a `map` on the src node, which calls set_value! on the dest node, and returns nothing). , e.g. from test/basics.jl "non-input bind":
+```
+s = Signal(1; name="sig 1")
+m = map(x->2x, s; name="m")
+s2 = Signal(3; name="sig 2")
+push!(m, 10) # s,m,s2 should be 1, 10, 3
+
+bind!(m, s2) # s,m,s2 should be 1, 3, 3
+
+push!(m, 6) # s,m,s2 should be 1, 6, 6
+
+push!(s2, 10) # s,m,s2 should be 1, 10, 10
+```
+1. fpswhen (the action to to set up the next tick/or stop the timer is on an auxilliary node with switch and the output node as the parents)
+
+Other
+1. every (doesn't actually have an action, just creates a timer to push to itself repeatedly)
+
+### GC and Preserve
+
+##### Docstring
+
+`preserve(signal::Signal)`
+
+prevents `signal` from being garbage collected (GC'd) as long as any of its `parents` are around. Useful for when you want to do some side effects in a signal.
+
+e.g. `preserve(map(println, x))` - this will continue to print updates to x, until x goes out of scope. `foreach` is a shorthand for `map` with `preserve`.
+
+##### Implementation
+
+1. `preserve(x)` iterates through the parents of `x` and increases the count of `p.preservers[x]` by 1, and calls `preserve(p)` for each parent `p` of `x`.
+1. Each signal has a field `preservers`, which is a `Dict{Signal, Int}`, which basically stores the number of times `preserve(x)` has been called on each of its child nodes `x`
+1. Crucially, this Dict holds an active reference to `x` which stops it from getting GC'd
+1. `unpreserve(x)` reduces the count of `preservers[x]` in all of x's parents, and if the count goes to 0, deletes the entry for (reference to) `x` in the `preservers` Dict thus freeing x for garbage collection.
+1. Both `preserve` and `unpreserve` are also called recursively on all parents/ancestors of `x`, this means that all ancestors of x in the signal graph will be preserved, until their parents are GC'd or `unpreserve` is called the same number of times as `preserve` was called on them, or any of their descendants.

--- a/src/async.jl
+++ b/src/async.jl
@@ -7,9 +7,9 @@ export remote_map,
 Spawn a new task to run a function when input signal updates. Returns a signal of tasks and a `results` signal which updates asynchronously with the results. `init` will be used as the default value of `results`. `onerror` is the callback to be called when an error occurs, by default it is set to a callback which prints the error to STDERR. It's the same as the `onerror` argument to `push!` but is run in the spawned task.
 """
 function async_map(f, init, inputs...; typ=typeof(init), onerror=print_error)
-
-    node = Signal(typ, init, inputs)
-    map(inputs...; init=nothing, typ=Any) do args...
+    node = Signal(typ, init) #results node
+    async_args = join(map(n->n.name, inputs), ", ")
+    map(inputs...; init=nothing, typ=Any, name="async_map ($async_args)")  do args...
         outer_task = current_task()
         @async begin
             try
@@ -28,9 +28,6 @@ end
 Spawn a new task on process `procid` to run a function when input signal updates. Returns a signal of remote refs and a `results` signal which updates asynchronously with the results. `init` will be used as the default value of `results`. `onerror` is the callback to be called when an error occurs, by default it is set to a callback which prints the error to STDERR. It's the same as the `onerror` argument to `push!` but is run in the spawned task.
 """
 function remote_map(procid, f, init, inputs...; typ=typeof(init), onerror=print_error)
-
-    node = Signal(typ, init, inputs)
-
     node = Signal(typ, init, inputs)
     map(inputs...; init=nothing, typ=Any) do args...
         outer_task = current_task()
@@ -47,4 +44,3 @@ function remote_map(procid, f, init, inputs...; typ=typeof(init), onerror=print_
         end
     end, node
 end
-

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -16,7 +16,9 @@ export map,
        droprepeats,
        flatten,
        bind!,
-       unbind!
+       unbind!,
+       bound_srcs,
+       bound_dests
 
 """
     map(f, s::Signal...) -> signal
@@ -33,16 +35,8 @@ function map(f, input::Signal, inputsrest::Signal...;
 end
 
 function connect_map(f, output, inputs...)
-    let prev_timestep = 0
-        for inp in inputs
-            add_action!(inp, output) do output, timestep
-                if prev_timestep != timestep
-                    result = f(map(value, inputs)...)
-                    send_value!(output, result, timestep)
-                    prev_timestep = timestep
-                end
-            end
-        end
+    add_action!(output) do
+        set_value!(output, f(map(value, inputs)...))
     end
 end
 
@@ -57,9 +51,11 @@ Same as `map`, but will be prevented from gc until all the inputs have gone out 
 foreach(f, in1::Signal, inputs::Signal...; kwargs...) = preserve(map(f, in1, inputs...; kwargs...))
 
 """
-    filter(f, signal)
+    filter(f, default, signal)
 
-remove updates from the signal where `f` returns `false`.
+remove updates from the `signal` where `f` returns `false`. The filter will hold
+the value default until f(value(signal)) returns true, when it will be updated
+to value(signal).
 """
 function filter{T}(f::Function, default, input::Signal{T}; name=auto_name!("filter", input))
     n = Signal(T, f(value(input)) ? value(input) : default, (input,); name=name)
@@ -68,9 +64,13 @@ function filter{T}(f::Function, default, input::Signal{T}; name=auto_name!("filt
 end
 
 function connect_filter(f, default, output, input)
-    add_action!(input, output) do output, timestep
+    add_action!(output) do
         val = value(input)
-        f(val) && send_value!(output, val, timestep)
+        if f(val)
+            set_value!(output, val)
+        else
+            deactivate!(output)
+        end
     end
 end
 
@@ -89,34 +89,36 @@ function filterwhen{T}(predicate::Signal{Bool}, default, input::Signal{T};
 end
 
 function connect_filterwhen(output, predicate, input)
-    add_action!(input, output) do output, timestep
-        value(predicate) && send_value!(output, value(input), timestep)
+    add_action!(output) do
+        if value(predicate)
+            set_value!(output, value(input))
+        else
+            deactivate!(output)
+        end
     end
 end
 
 """
-    foldp(f, init, input)
+    foldp(f, init, inputs...)
 
 [Fold](http://en.wikipedia.org/wiki/Fold_(higher-order_function)) over past values.
 
-Accumulate a value as the `input` signal changes. `init` is the initial value of the accumulator.
-`f` should take 2 arguments: the current accumulated value and the current update, and result in the next accumulated value.
+Accumulate a value as the input signals change. `init` is the initial value of the accumulator.
+`f` should take `1 + length(inputs)` arguments: the first is the current accumulated value and the rest are the current input signal values. `f` will be called when one or more of the `inputs` updates. It should return the next accumulated value.
 """
-function foldp(f::Function, v0, inputs...; typ=typeof(v0), name=auto_name!("foldp", inputs...))
-    n = Signal(typ, v0, inputs; name=name)
-    connect_foldp(f, v0, n, inputs)
+function foldp(f::Function, v0, input::Signal, inputsrest::Signal...;
+        typ=typeof(v0), name=auto_name!("foldp", input, inputsrest...))
+    n = Signal(typ, v0, (input, inputsrest...); name=name)
+    connect_foldp(f, v0, n, (input, inputsrest...))
     n
 end
 
 function connect_foldp(f, v0, output, inputs)
-    let acc = v0
-        for inp in inputs
-            add_action!(inp, output) do output, timestep
-                vals = map(value, inputs)
-                acc = f(acc, vals...)
-                send_value!(output, acc, timestep)
-            end
-        end
+    acc = v0
+    add_action!(output) do
+        vals = map(value, inputs)
+        acc = f(acc, vals...)
+        set_value!(output, acc)
     end
 end
 
@@ -125,44 +127,67 @@ end
 
 Sample the value of `b` whenever `a` updates.
 """
-function sampleon{T}(sampler, input::Signal{T}; name=auto_name!("sampleon", input))
-    n = Signal(T, value(input), (sampler, input); name=name)
-    connect_sampleon(n, sampler, input)
+function sampleon{T}(sample_trigger, input::Signal{T}; name=auto_name!("sampleon", input))
+    n = Signal(T, value(input), (sample_trigger,); name=name)
+    connect_sampleon(n, input)
     n
 end
 
-function connect_sampleon(output, sampler, input)
-    add_action!(sampler, output) do output, timestep
-        send_value!(output, value(input), timestep)
+function connect_sampleon(output, input)
+    # this will only get run when sampler updates, as sample_trigger is output's
+    # only parent
+    add_action!(output) do
+        set_value!(output, input.value)
     end
 end
-
 
 """
     merge(inputs...)
 
 Merge many signals into one. Returns a signal which updates when
 any of the inputs update. If many signals update at the same time,
-the value of the *youngest* input signal is taken.
+the value of the *youngest* (most recently created) input signal is taken.
 """
 function merge(in1::Signal, inputs::Signal...; name=auto_name!("merge", in1, inputs...))
-    n = Signal(typejoin(map(eltype, (in1, inputs...))...), value(in1), (in1, inputs...); name=name)
+    ins = (in1, inputs...)
+    youngestid = maximum(map(x->x.id, ins))
+    youngest_val = nodes[youngestid].value
+    n = Signal(typejoin(map(eltype, ins)...), value(youngest_val), ins; name=name)
     connect_merge(n, in1, inputs...)
     n
 end
 
 function connect_merge(output, inputs...)
-    let prev_timestep = 0
-        for inp in inputs
-            add_action!(inp, output) do output, timestep
-                # don't update twice in the same timestep
-                if prev_timestep != timestep
-                    send_value!(output, value(inp), timestep)
-                    prev_time = timestep
-                end
-            end
-        end
+    function merge_action()
+        lastactive = getlastactive(output)
+        lastactive != nothing && set_value!(output, value(lastactive))
+        # we don't deactivate! on lastactive == nothing, since I suppose the push
+        # should propagate even if some of the nodes died just after updating.
     end
+    add_action!(merge_action, output)
+end
+
+"""
+`getlastactive(merge_node)`
+Search backwards in nodes, and return the first active node that is one
+of merge_node's parents
+"""
+function getlastactive(merge_node)
+    i = merge_node.id - 1
+    while i > 0
+        node = nodes[i].value
+        if isactive(node) && node in merge_node.parents
+            return node
+        end
+        i -= 1
+    end
+    # If parent nodes have all been GC'd, but there is still a reference to the
+    # merge in user code, then none of the parents should have been active,
+    # so the merge action shouldn't run, so we shouldn't have got here. However,
+    # in the rare case that the node got GC'd after it was found to be an active
+    # parent of the merge but before we got here, then I guess the merge node
+    # shouldn't change value.
+    return nothing
 end
 
 """
@@ -178,11 +203,10 @@ function previous{T}(input::Signal{T}, default=value(input); name=auto_name!("pr
 end
 
 function connect_previous(output, input)
-    let prev_value = value(input)
-        add_action!(input, output) do output, timestep
-            send_value!(output, prev_value, timestep)
-            prev_value = value(input)
-        end
+    prev_value = value(input)
+    add_action!(output) do
+        set_value!(output, prev_value)
+        prev_value = value(input)
     end
 end
 
@@ -201,9 +225,12 @@ function delay{T}(input::Signal{T}, default=value(input); name=auto_name!("delay
 end
 
 function connect_delay(output, input)
-    add_action!(input, output) do output, timestep
-        push!(output, value(input))
+    function push_delayed(inpval)
+        # only push when input is active (avoids it pushing to itself endlessly)
+        push!(output, inpval)
+        nothing
     end
+    foreach(push_delayed, input; init=nothing)
 end
 
 """
@@ -219,12 +246,13 @@ function droprepeats{T}(input::Signal{T}; name=auto_name!("droprepeats", input))
 end
 
 function connect_droprepeats(output, input)
-    let prev_value = value(input)
-        add_action!(input, output) do output, timestep
-            if prev_value != value(input)
-                send_value!(output, value(input), timestep)
-                prev_value = value(input)
-            end
+    prev_value = value(input)
+    add_action!(output) do
+        if prev_value != value(input)
+            set_value!(output, value(input))
+            prev_value = value(input)
+        else
+            deactivate!(output)
         end
     end
 end
@@ -237,71 +265,147 @@ value of the current signal. The `typ` keyword argument specifies
 the type of the flattened signal. It is `Any` by default.
 """
 function flatten(input::Signal; typ=Any, name=auto_name!("flatten", input))
-    n = Signal(typ, value(value(input)), (input,); name=name)
+    n = Signal(typ, input.value.value, (input, input.value); name=name)
     connect_flatten(n, input)
     n
 end
 
+
+"""
+`connect_flatten(output, input)`
+`output` is the flatten node, `input` is the Signal{Signal} ("sigsig") node
+Descendents of this flatten node need to know to update on changes to
+the input sigsig (allroots(input)), or changes to the value of the
+current sig (roots == allroots(current_node))
+"""
 function connect_flatten(output, input)
-    let current_node = value(input),
-        callback = (output, timestep) -> begin
-            send_value!(output, value(value(input)), timestep)
-        end
-
-        add_action!(callback, current_node, output)
-
-        add_action!(input, output) do output, timestep
-
-            # Move around action from previous node to current one
-            remove_action!(callback, current_node, output)
-            current_node = value(input)
-            add_action!(callback, current_node, output)
-
-            send_value!(output, value(current_node), timestep)
+    # input is a Signal{Signal} (aka sigsig), current_node is the signal/node
+    # that is the input's current value. wire_flatten sets the flatten's
+    # parents, to (input, input.value), when the sigsig gets a new signal as its
+    # value. This ensures that both set_flatten_val and wire_flatten will be run
+    # (and flatten output node's value will update) when either the current_node
+    # updates, or when the input sigsig updates.
+    current_node = input.value
+    wire_flatten() = begin
+        # If the sigsig's value has changed update output's parents so it will
+        # only update when the new current_node updates, and no longer
+        # update when the previous signal updates.
+        if current_node != input.value
+            current_node = input.value
+            output.parents = (input, current_node)
         end
     end
+
+    set_flatten_val() = set_value!(output, current_node.value)
+    add_action!(wire_flatten, output)
+    add_action!(set_flatten_val, output) # this must come after wire_flatten
 end
 
-const _bindings = Dict()
+const _bindings = Dict() # XXX GC Issue? can't use WeakKeyDict with Pairs...
+const _active_binds = Dict()
 
 """
-    bind!(a,b,twoway=true)
+    `bind!(dest, src, twoway=true)`
 
-for every update to `a` also update `b` with the same value and vice-versa.
-To only bind updates from b to a, pass in a third argument as `false`
+for every update to `src` also update `dest` with the same value and, if
+`twoway` is true, vice-versa.
 """
-function bind!(a::Signal, b::Signal, twoway=true)
-
-    let current_timestep = 0
-        action = add_action!(b, a) do a, timestep
-            if current_timestep != timestep
-                current_timestep = timestep
-                send_value!(a, value(b), timestep)
-            end
+function bind!(dest::Signal, src::Signal, twoway=true)
+    if haskey(_bindings, src=>dest)
+        # subsequent bind!(dest, src) after initial should be a no-op
+        # though we should allow a change in preference for twoway bind.
+        if twoway
+            bind!(src, dest, false)
         end
-        _bindings[a=>b] = action
-    end
-
-    if twoway
-        bind!(b, a, false)
-    end
-end
-
-"""
-    unbind!(a,b,twoway=true)
-
-remove a link set up using `bind!`
-"""
-function unbind!(a::Signal, b::Signal, twoway=true)
-    if !haskey(_bindings, a=>b)
         return
     end
 
-    action = _bindings[a=>b]
-    b.actions = filter(x->x!=action, b.actions)
-    delete!(_bindings, a=>b)
+    # We don't set src as a parent of dest, since a
+    # two-way bind would technically introduce a cycle into the signal graph,
+    # and I suppose we'd prefer not to have that. Instead we just set dest as
+    # active when src updates, which will allow its downstream actions to run.
+
+    ordered_pair = src.id < dest.id ? src=>dest : dest=>src # ordered by id
+    twoway && (_active_binds[ordered_pair] = false)
+    # the binder action comes after dest, so dest's downstream actions
+    # won't run unless we arrange it.
+    function bind_updater(srcval)
+        if !haskey(_bindings, src=>dest)
+            # will happen if has been unbound but node not gc'd
+            return
+        end
+        is_twoway = haskey(_active_binds, ordered_pair)
+        if is_twoway && _active_binds[ordered_pair]
+            # The _active_binds flag stops the (infinite) cycle of src
+            # updating dest updating src ... in the case of a two-way bind
+            _active_binds[ordered_pair] = false
+        else
+            is_twoway && (_active_binds[ordered_pair] = true)
+            # we "pause" the current push!, simulate a push! to dest with
+            # run_push then resume processing the original push by reactivating
+            # the previously active nodes.
+            active_nodes = pause_push()
+            run_push(dest, src.value, onerror_rethrow, false) # false for dont_remove_dead - messes with active_nodes
+            foreach(activate!, active_nodes)
+        end
+        nothing
+    end
+    finalizer(src, (src)->unbind!(dest, src, twoway))
+
+    _bindings[src=>dest] = map(bind_updater, src; name="binder: $(src.name)=>$(dest.name)")
+    bind_updater(src.value) # init now that _bindings[src=>dest] is set
 
     if twoway
-        unbind!(b, a, false)
+        bind!(src, dest, false)
+    end
+
+end
+
+"""
+    `unbind!(dest, src, twoway=true)`
+
+remove a link set up using `bind!`
+"""
+function unbind!(dest::Signal, src::Signal, twoway=true)
+    if !haskey(_bindings, src=>dest)
+        return
+    end
+
+    _bindings[src=>dest] != nothing && close(_bindings[src=>dest])
+    delete!(_bindings, src=>dest)
+
+    ordered_pair = src.id < dest.id ? src=>dest : dest=>src # ordered by id
+    haskey(_active_binds, ordered_pair) && delete!(_active_binds, ordered_pair)
+
+    if twoway
+        unbind!(src, dest, false)
     end
 end
+
+"""
+Pause a push by recording the active nodes and setting them to inactive.
+The push can be resumed by reactivating the nodes.
+"""
+function pause_push()
+    active_nodes = WeakRef[]
+    for noderef in nodes
+        node = noderef.value
+        if isactive(node)
+            push!(active_nodes, WeakRef(node))
+            deactivate!(node)
+        end
+    end
+    active_nodes
+end
+
+"""
+`bound_dests(src::Signal)` returns a vector of all signals that will update when
+`src` updates, that were bound using `bind!(dest, src)`
+"""
+bound_dests(s::Signal) = [dest for (src, dest) in keys(_bindings) if src == s]
+
+"""
+`bound_srcs(dest::Signal)` returns a vector of all signals that will cause
+an update to `dest` when they update, that were bound using `bind!(dest, src)`
+"""
+bound_srcs(s::Signal) = [src for (src, dest) in keys(_bindings) if dest == s]

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,9 +1,36 @@
-export every, fps, fpswhen, throttle
+export every, fps, fpswhen, throttle, debounce
 
 """
-    throttle(dt, input, f=(acc,x)->x, init=value(input), reinit=x->x)
+```
+debounce(dt, input, f=(acc,x)->x, init=value(input), reinit=x->x;
+            typ=typeof(init), name=auto_name!(string("debounce ",dt,"s"), input))
+```
 
-Throttle a signal to update at most once every dt seconds. By default, the throttled signal holds the last update in the time window.
+Creates a signal that will delay updating until `dt` seconds have passed since the last time `input` has updated. By default, the debounce signal holds the last update of the `input` signal since the debounce signal last updated.
+
+This behavior can be changed by the `f`, `init` and `reinit` arguments. The `init` and `f` functions are similar to `init` and `f` in `foldp`. `reinit` is called after the debounce sends an update, to reinitialize the initial value for accumulation, it gets one argument, the previous accumulated value.
+
+For example
+    `y = debounce(0.2, x, push!, Int[], _->Int[])`
+will accumulate a vector of updates to the integer signal `x` and push it after `x` is inactive (doesn't update) for 0.2 seconds.
+
+"""
+function debounce{T}(dt, node::Signal{T}, f=(acc,x)->x, init=value(node),
+        reinit=x->x; typ=typeof(init), name=auto_name!("debounce $(dt)s", node))
+    # we don't add `node` as a parent of throttle, as the action is added to the
+    # `node` itself, which pushes to the output node at the appropriate time.
+    output = Signal(typ, init, (); name=name)
+    throttle_connect(dt, output, node, f, init, reinit, false, true)
+    output
+end
+
+"""
+```
+throttle(dt, input, f=(acc,x)->x, init=value(input), reinit=x->x;
+            typ=typeof(init), name=auto_name!(string("throttle ",dt,"s"), input), leading=false)
+```
+
+Throttle a signal to update at most once every dt seconds. By default, the throttled signal holds the last update of the `input` signal during each `dt` second time window.
 
 This behavior can be changed by the `f`, `init` and `reinit` arguments. The `init` and `f` functions are similar to `init` and `f` in `foldp`. `reinit` is called when a new throttle time window opens to reinitialize the initial value for accumulation, it gets one argument, the previous accumulated value.
 
@@ -11,28 +38,54 @@ For example
     `y = throttle(0.2, x, push!, Int[], _->Int[])`
 will create vectors of updates to the integer signal `x` which occur within 0.2 second time windows.
 
+If `leading` is `true`, the first update from `input` will be sent immediately by the throttle signal. If it is false, the first update will happen `dt` seconds after `input`'s first update
+
+New in v0.4.1: `throttle`'s behaviour from previous versions is now available with the `debounce` signal type.
+
 """
-function throttle{T}(dt, node::Signal{T}, f=(acc,x)->x, init=value(node), reinit=x->x; typ=typeof(init), name=auto_name!("throttle $(dt)s", node))
+function throttle{T}(dt, node::Signal{T}, f=(acc,x)->x, init=value(node),
+        reinit=x->x; typ=typeof(init), name=auto_name!("throttle $(dt)s", node),
+        leading=false)
     output = Signal(typ, init, (node,); name=name)
-    throttle_connect(dt, output, node, f, init, reinit)
+    throttle_connect(dt, output, node, f, init, reinit, leading, false)
     output
 end
 
 # Aggregate a signal producing an update at most once in dt seconds
-function throttle_connect(dt, output, input, f, init, reinit)
-    let collected = init, timer = Timer(x->x, 0)
-        add_action!(input, output) do output, timestep
-            collected = f(collected,  value(input))
-            close(timer)
-            timer = Timer(x -> begin push!(output, collected); collected=reinit(collected) end, dt)
-        end
+function throttle_connect(dt, output, input, f, init, reinit, leading, debounce)
+    collected = init
+    timer = Timer(identity, 0) #dummy timer to initialise
+    dopush(_) = begin
+        push!(output, collected)
+        collected = reinit(collected)
+        prevpush = time()
     end
+
+    # we add the do_throttle as a foreach on the input, so when input updates it
+    # collects the input values and pushes to the output when the time is right.
+    prevpush = 0 # immediate push of `input`'s first update (unless leading is false)
+    function do_throttle(inpval)
+        collected = f(collected, inpval)
+        prevpush == 0 && !leading && (prevpush = time())
+        elapsed = time() - prevpush
+        debounce && (elapsed = 0) # for debounce, only the timer can trigger a push
+
+        close(timer)
+        if elapsed > dt
+            # prevpush is reset in dopush, so that calls via the Timer also reset it
+            dopush(elapsed)
+        else
+            timer = Timer(dopush, dt-elapsed)
+        end
+        nothing
+    end
+    foreach(do_throttle, input; init=nothing, name="$(input.name) throttler")
 end
 
 """
     every(dt)
 
-A signal that updates every `dt` seconds to the current timestamp. Consider using `fpswhen` or `fps` before using `every`.
+A signal that updates every `dt` seconds to the current timestamp. Consider using `fpswhen` or `fps` if you want specify the timing signal by frequency, rather than delay.
 """
 function every(dt; name=auto_name!("every $dt secs"))
     n = Signal(time(), (); name=name)
@@ -42,7 +95,11 @@ end
 
 function every_connect(dt, output)
     outputref = WeakRef(output)
-    timer = Timer(x -> _push!(outputref, time(), ()->close(timer)), dt, dt)
+    function onerror_close_timer(pushnode, val, error_node, ex)
+        print_error(pushnode, val, error_node, ex)
+        close(timer)
+    end
+    timer = Timer(x -> push!(outputref.value, time(), onerror_close_timer), dt, dt)
     finalizer(output, _->close(timer))
     output
 end
@@ -53,36 +110,48 @@ end
 returns a signal which when `switch` signal is true, updates `rate` times every second. If `rate` is not possible to attain because of slowness in computing dependent signal values, the signal will self adjust to provide the best possible rate.
 """
 function fpswhen(switch, rate; name=auto_name!("$rate fpswhen", switch))
-    switch_ons = filter(x->x, false, switch) # only turn-ons
-    n = Signal(Float64, 0.0, (switch, switch_ons,); name=name)
-    fpswhen_connect(rate, switch, switch_ons, n)
+    # Creates a node and sets up a timer that pushes to the node every 1.0/rate
+    # seconds.
+    n = Signal(Float64, 0.0, (switch, ); name=name)
+    fpswhen_connect(rate, switch, n, name)
     n
 end
 
 function setup_next_tick(outputref, switchref, dt, wait_dt)
-    if value(switchref.value)
-        Timer(t -> if value(switchref.value)
-                       _push!(outputref, dt)
-                   end, wait_dt)
-    end
+    Timer(t -> begin
+        if value(switchref.value)
+            push!(outputref.value, dt)
+        end
+    end, wait_dt)
 end
 
-function fpswhen_connect(rate, switch, switch_ons, output)
-    let prev_time = time()
-        dt = 1.0/rate
-        outputref = WeakRef(output)
-        switchref = WeakRef(switch)
-
-        for inp in [output, switch_ons]
-            add_action!(inp, output) do output, timestep
-                start_time = time()
-                setup_next_tick(outputref, switchref, start_time-prev_time, dt)
-                prev_time = start_time
-            end
+function fpswhen_connect(rate, switch, output, name)
+    prev_time = time()
+    dt = 1.0/rate
+    outputref = WeakRef(output)
+    switchref = WeakRef(switch)
+    timer = Timer(identity, 0) # dummy timer to initialise
+    function fpswhen_runner()
+        # this function will run if switch gets a new value (i.e. is "active")
+        # and if output is pushed to (assumed to be by the timer)
+        if switch.value
+            start_time = time()
+            timer = setup_next_tick(outputref, switchref, start_time-prev_time, dt)
+            prev_time = start_time
+        else
+            close(timer)
         end
-
-        setup_next_tick(outputref, switchref, dt, dt)
+        switch.value
     end
+    # the fpswhen_aux will start and stop the timer if switch's value updates, it'll
+    # also setup the next tick once the first tick is pushed to output
+    fpswhen_aux = Signal(switch.value, (switch, output); name="fpswhen runner switch: $(switch.name), output: $(output.name)")
+    preserve(fpswhen_aux)
+    add_action!(fpswhen_runner, fpswhen_aux)
+
+    fpswhen_runner() # init
+    # ensure timer stops when output node is garbage collected
+    finalizer(output, _->close(timer))
 end
 
 """

--- a/test/async.jl
+++ b/test/async.jl
@@ -1,17 +1,19 @@
-
 facts("Async") do
 
     context("async_map") do
-        x = Signal(1)
+        x = Signal(1; name="x")
         t, y = async_map(-, 0, x)
+        z = map(yv->2yv, y; name="z")
 
         @fact value(t) --> nothing
         @fact value(y) --> 0
+        @fact value(z) --> 0
 
         push!(x, 2)
         step()
         step()
 
         @fact value(y) --> -2
+        @fact value(z) --> -4
     end
 end

--- a/test/call_count.jl
+++ b/test/call_count.jl
@@ -34,41 +34,5 @@ facts("Call counting") do
         @fact ce.value --> i
         @fact cf.value --> 2i
     end
-end
 
-facts("multi-path graphs") do
-    a = Signal(0)
-    b = Signal(0)
-
-    c = map(+, a, b)
-    d = merge(a, b)
-    e = map(+, a, map(x->2x, a)) # Both depend on a
-    f = map(+, a, b, c, e)
-
-    for (av,bv) in [(1,2),(1,3),(7,7)]
-        push!(a, av)
-        push!(b, bv-1)
-        Reactive.run_till_now()
-        push!(b, bv)
-        Reactive.run_till_now()
-        @fact value(c) --> av + bv
-        @fact value(e) --> 3av
-        @fact value(d) --> bv
-        @fact value(f) --> 5av + 2bv
-    end
-
-    xv = 2
-    x = Signal(xv)
-    y = map(identity, x)
-    x2 = map(x->2x, x)
-    z = map(+, y, x2)
-    Reactive.run_till_now()
-    @fact value(y) --> xv
-    @fact value(x2) --> 2xv
-    @fact value(z) --> 3xv
-
-    xv2 = xv + 1
-    push!(x, xv2)
-    Reactive.run_till_now()
-    @fact value(z) --> 3xv2
 end

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -1,6 +1,3 @@
-using Base.Test
-using Reactive
-
 facts("Flatten") do
 
     a = Signal(0)
@@ -18,7 +15,6 @@ facts("Flatten") do
     end
 
     context("Initial update count") do
-
         @fact value(cnt) --> 0
     end
 
@@ -47,4 +43,49 @@ facts("Flatten") do
         @fact value(cnt) --> 3
         @fact value(d) --> value(b)
     end
+
+    context("Subtle sig swap issue") do
+        # When a node, a map (e) in this case, has a flatten as a parent, but also
+        # a signal that is the flatten parent sigsig's (c's) current value ("a" here)
+        # then when the sigsig gets pushed another value, you want the map to
+        # still update on changes to a, even after the map is "rewired" when a
+        # new value is pushed to c.
+
+        a = Signal(1)
+        b = Signal(2)
+        c = Signal(a)
+        d = flatten(c)
+        e = map(*, a, d) #e is dependent on "a" directly and through d
+
+        @fact value(e) --> 1
+        push!(a, 3)
+        step()
+        @fact value(a) --> 3
+        @fact value(d) --> 3
+        @fact value(e) --> 9
+
+        push!(c, b)
+        @fact value(e) --> 9 # no change until step
+        step()
+        @fact value(d) --> 2 # d now takes b's value
+        @fact value(e) --> 6 # e == d * a == 2 * 3 == 6
+
+        # the push!(c, b) should have triggered a "rewiring" of the graph
+        # so that updates to b affect d and e
+        push!(b, 9)
+        step()
+        @fact value(d) --> 9  # d now takes b's value
+        @fact value(e) --> 27 # e == d * a == 9 * 3 == 27
+
+        # changes to a should still affect e (but not d)
+        push!(a, 4)
+        @fact value(e) --> 27 # no change until step
+        step()
+        @fact value(a) --> 4
+        @fact value(d) --> 9 # no change to d
+        @fact value(e) --> 36 # a*d == 4 * 9
+
+        @fact queue_size() --> 0
+    end
+
 end

--- a/test/node_order.jl
+++ b/test/node_order.jl
@@ -1,0 +1,154 @@
+facts("multi-path graphs 1") do
+    a = Signal(0)
+    b = Signal(0)
+
+    c = map(+, a, b)
+    d = merge(a, b)
+    e = map(+, a, map(x->2x, a)) # Both depend on a
+    f = map(+, a, b, c, e)
+
+    @fact queue_size() --> 0
+
+    for (av,bv) in [(1,2),(1,3),(7,7)]
+        @show av bv
+        push!(a, av)
+        push!(b, bv-1)
+        Reactive.run_till_now()
+        push!(b, bv)
+        Reactive.run_till_now()
+        @fact value(c) --> av + bv
+        @fact value(e) --> 3av
+        @fact value(d) --> bv
+        @fact value(f) --> 5av + 2bv
+    end
+
+    xv = 2
+    x = Signal(xv)
+    y = map(identity, x)
+    x2 = map(x->2x, x)
+    z = map(+, y, x2)
+    Reactive.run_till_now()
+    @fact value(y) --> xv
+    @fact value(x2) --> 2xv
+    @fact value(z) --> 3xv
+
+    xv2 = xv + 1
+    push!(x, xv2)
+    Reactive.run_till_now()
+    @fact value(z) --> 3xv2
+end
+
+facts("multi-path graphs 2") do
+    a = Signal(0)
+    b = Signal(0)
+
+    c = map(+, a, b)
+    d = merge(a, b)
+    e = map(+, a, map(x->2x, a)) # Both depend on a
+    f = map(+, a, b, c, e)
+
+    for (av,bv) in [(1,2),(1,3),(7,7)]
+        push!(a, av)
+        push!(b, bv-1)
+        Reactive.run_till_now()
+        push!(b, bv)
+        Reactive.run_till_now()
+        @fact value(c) --> av + bv
+        @fact value(e) --> 3av
+        @fact value(d) --> bv
+        @fact value(f) --> 5av + 2bv
+    end
+
+    xv = 2
+    x = Signal(xv)
+    y = map(identity, x)
+    x2 = map(x->2x, x)
+    z = map(+, y, x2)
+    Reactive.run_till_now()
+    @fact value(y) --> xv
+    @fact value(x2) --> 2xv
+    @fact value(z) --> 3xv
+
+    xv2 = xv + 1
+    push!(x, xv2)
+    Reactive.run_till_now()
+    @fact value(z) --> 3xv2
+end
+
+facts("multi-path graphs: dfs good, bfs bad") do
+    # DFS good, BFS bad
+    # s4x is initially 8 (4*2), after push!(sx,3), s4x should be 12 (4*3), but is instead 9.
+    # initially: sx is 2, s2x is 4, s3x is 6, s4x is 8
+    # after push!(sx, 3), what happens is:
+    # BFS
+        # order: sx, s2x, s4x, s3x (bad)
+        # sx is updated to 3, s2x updates correctly (to 6), but then s4x is next in the queue,
+        # and sees s3x's old value of 6, adds it to sx (3), and gets 9. Finally s3x updates
+        # correctly to 9, but it's all too late
+    # DFS
+        # order: sx, s2x, s3x, s4x (good)
+    xv = 2
+    sx = Signal(xv; name="sx")
+    s2x = map(x->2x, sx; name="s2x")
+    s3x = map(x->x + x÷2, s2x; name="s3x")
+    s4x = map(+, sx, s3x; name="s4x")
+    @fact value.([sx, s2x, s3x, s4x]) --> [2, 4, 6, 8]
+    push!(sx, 3)
+    Reactive.run_till_now()
+    @fact value.([sx, s2x, s3x, s4x]) --> [3, 6, 9, 12]
+end
+
+facts("multi-path graphs: bfs good, dfs bad") do
+    #BFS good, DFS bad
+    # s3x is initially 6 (3*2), after push!(sx, 3), s3x should be 9 (3*3), but is instead 7.
+    # initially: sx and s1x1, s1x2 are 2, s2x is 4, s3x is 6
+    # after push!(sx, 3), what happens is:
+    # DFS:
+        # order sx, s1x1, s3x, s1x2 (bad)
+        # sx is updated to 3, s1x1 updates correctly (to 3), but then s3x is next in the queue,
+        # and sees s1x2's old value of 2, adds it to sx (3), s1x1(3) and gets 8. Finally s1x2 updates
+        # correctly to 3, but it's all too late
+    # BFS:
+        # order sx, s1x1, s1x2, sx3 (good)
+    xv = 2
+    sx = Signal(xv)
+    s1x1 = map(identity, sx)
+    s1x2 = map(identity, sx)
+    s3x = map(+, s1x1, s1x2, sx)
+    @fact value.([sx, s1x1, s1x2, s3x]) --> [2, 2, 2, 6]
+    push!(sx, 3)
+    Reactive.run_till_now()
+    @fact value.([sx, s1x1, s1x2, s3x]) --> [3, 3, 3, 9]
+end
+
+facts("multi-path graphs: dfs bad, bfs bad") do
+    #BFS bad, dfs bad
+    # s3x is initially 6 (3*2), after push!(sx, 3), s3x should be 9 (3*3), but is instead 7.
+    # what happens in BFS is:
+    # initially: sx and s1x1, s1x2 are 2, s2x is 4, s3x is 6
+    # after push!(sx, 3)
+    # BFS:
+        # order is x, s1x1, s1x2, s3x, s2x (bad)
+        # correct: x, s1x1, s1x2, s2x, s3x)
+        # sx is updated to 3, s1x1 and s1x2 update correctly (to 3), but s3x is next in the queue,
+        # and sees s2x's old value of 4, adds it to sx (3), and gets 7. Finally s2x updates
+        # correctly to 6 (2*3), but it's all too late
+    # DFS:
+        # order is x, s1x1, s2x, s3x, s1x2 (bad)
+        # correct: x, s1x1, s1x2, s2x, s3x)
+        # sx is updated to 3, s1x1 updates correctly to 3, but then:
+        # s2x sees s1x2 as 2 and updates to 5 (3 + 2) - but should be 6, then
+        # s3x sees s2x as 5, adds sx (3) and gets 8
+        # s1x2 then updates to 3, but that's it, s2x is 5 (not 6), s3x is 8 (not 9)
+
+    xv = 2
+    sx = Signal(xv)
+    s1x1 = map(identity, sx)
+    s1x2 = map(identity, sx)
+    s2x = map(+, s1x1, s1x2)
+    s3x = map(+, sx, s2x)
+    @fact value.([sx, s1x1, s1x2, s2x, s3x]) --> [2, 2, 2, 4, 6]
+    push!(sx, 3)
+    Reactive.run_till_now()
+    @fact value.([sx, s1x1, s1x2, s2x, s3x]) --> [3, 3, 3, 6, 9]
+end

--- a/test/push_to_non_input.jl
+++ b/test/push_to_non_input.jl
@@ -1,0 +1,127 @@
+using Reactive
+
+function standard_push_test(non_input::Signal)
+    m = map(x->2x, non_input)
+    pval = number()
+    push!(non_input, pval)
+    step()
+
+    @fact value(non_input) --> pval
+    @fact value(m) --> 2pval
+end
+
+facts("Push to non-input nodes") do
+
+    a = Signal(number(); name="a")
+    b = map(x -> x*x, a; name="b")
+
+    context("push to map") do
+        m = map(x->2x, b)
+
+        push!(b, 10.0)
+        step()
+        @fact value(b) --> 10.0
+        @fact value(m) --> 2value(b)
+
+        push!(a, 2.0)
+        step()
+        @fact value(b) --> 4.0
+        @fact value(m) --> 2value(b)
+
+        push!(b, 3.0)
+        step()
+        @fact value(b) --> 3.0
+        @fact value(m) --> 2value(b)
+    end
+
+
+    context("push to merge") do
+        ## Merge
+        d = Signal(number(); name="d")
+        e = merge(b, d, a; name="e")
+        m = map(x->2x, e)
+        # precedence to d
+        @fact value(e) --> value(d)
+        @fact value(m) --> 2value(e)
+
+        standard_push_test(e)
+    end
+
+    context("push to foldp") do
+        gc()
+        f = foldp(+, 0, a)
+        m = map(x->2x, f)
+
+        standard_push_test(f)
+    end
+
+    context("push to filter") do
+        g = Signal(0)
+        pred = x -> x % 2 != 0
+        h = filter(pred, 1, g)
+        standard_push_test(h)
+    end
+
+    context("push to sampleon") do
+        # sampleon
+        g = Signal(0)
+        nv = number()
+        push!(g, nv)
+        step()
+        i = Signal(true)
+        j = sampleon(i, g)
+        standard_push_test(j)
+    end
+
+    context("push to droprepeats") do
+        # droprepeats
+        k = Signal(1)
+        l = droprepeats(k)
+
+        standard_push_test(l)
+    end
+
+    context("push to filterwhen") do
+        # filterwhen
+        b = Signal(false)
+        n = Signal(1)
+        dw = filterwhen(b, 0, n)
+        standard_push_test(dw)
+    end
+
+    context("push to previous") do
+        x = Signal(0)
+        y = previous(x)
+        standard_push_test(y)
+    end
+
+    context("push to delay") do
+        x = Signal(0)
+        y = delay(x)
+        standard_push_test(y)
+    end
+
+    context("bind non-input") do
+        s = Signal(1; name="sig 1")
+        m = map(x->2x, s; name="m")
+        s2 = Signal(3; name="sig 2")
+        push!(m, 10)
+        step()
+        @fact value(m) --> 10
+
+        bind!(m, s2) #two-way bind
+        @fact value(m) --> 3
+        @fact value(s2) --> 3
+
+        push!(m, 6)
+        step()
+        @fact value(m) --> 6
+        @fact value(s2) --> 6
+
+        push!(s2, 10)
+        step()
+        @fact value(m) --> 10
+        @fact value(s2) --> 10
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Reactive
+using FactCheck
 
 # Stop the runner task
 
@@ -7,8 +8,14 @@ if !istaskdone(Reactive.runner_task)
     wait(Reactive.runner_task)
 end
 
+step() = Reactive.run(1)
+queue_size() = Base.n_avail(Reactive._messages)
+number() = round(Int, rand()*1000)
+
 include("basics.jl")
-#include("gc.jl")
+include("push_to_non_input.jl")
+# include("gc.jl")
+include("node_order.jl")
 include("call_count.jl")
 include("flatten.jl")
 include("time.jl")


### PR DESCRIPTION
Finally got around to cleaning this branch up.

This PR:

1. Gets signals updating in ~~the~~ a correct (topological) order (the order Signals are created), which fixes bugs in signals updating on certain signal graphs. See the last three test sets [here](https://github.com/JobJob/Reactive.jl/blob/action_queues_redesign/test/node_order.jl) for examples of where the current (breadth-first) and pre #113 (depth-first) designs had bugs.
2. Makes async optional through `Reactive.run_async(false)` - though it's not well tested, so async is on by default.
3. Runs faster than current master on @SimonDanisch's benchmark - included in https://github.com/JobJob/Reactive.jl/blob/action_queues_redesign/benchmark/ReactBench.jl - and slightly (though not much) faster in synchronous mode. Is now around 2.5x slower than the non-reactive version on my machine (previous master was about 4x slower).
4. Adds a PkgBenchmark - based off Shashi's speedups_maybe branch.
5. Fixes a bug in error reporting.
6. Adds a small amount of docs about the [design](https://github.com/JobJob/Reactive.jl/blob/action_queues_redesign/doc/Design%20Overview.md) and the [garbage collection/preserve](https://github.com/JobJob/Reactive.jl/blob/action_queues_redesign/doc/dev%20notes.md) mechanism.
7. adds `bound_srcs`, `bound_dests` see OP of #119 
8. Adds `debounce` - which behaves as per previous throttle
9. Fixes `throttle` issue in #123, but note this changes the behaviour of throttle, use debounce if you want the previous behaviour.

Downsides:

1. ~~Can't `push!` to non input nodes - those created with `Signal(...)`~~ you can now
1. ~~`flatten`~~ `bind` implementation is a little bit more complicated, though may be more correct in some cases.
1. May have bugs that aren't tested for in the tests, since the design is a little different.
1. ~~Haven't checked if it plays nice with Garbage Collection~~

Todo:

- [x] Fix interaction with Garbage Collection
- [x] Clean up some references in comments to action_queue
- [x] Add NEWS.md entry about throttle.
- [x] Fix `debug_memory` code
- [x] Make throttle tests more robust
- [x] Fix Travis test failures