### PR TITLE
Fix world-age problems on 0.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ using Reactive
 
 # Stop the runner task
 
-try
+if !istaskdone(Reactive.runner_task)
     Reactive.stop()
-catch
+    wait(Reactive.runner_task)
 end
 
 include("basics.jl")


### PR DESCRIPTION
Interestingly, the `wait(Reactive.runner_task)` in `test/runtests.jl` is probably something we should have had all along; there was always a chance that some of the queue would have been processed before the event loop shut down.