### PR TITLE
added a modified bind! version

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -370,6 +370,26 @@ function bind!(dest::Signal, src::Signal, twoway=true; initial=true)
 end
 
 """
+    `bind!(dest, src2dest, src, dest2src=nothing; initial=true)`
+
+for every update to `src` also update `dest` with a modified value (using the
+function `src2dest`) and, if `dest2src` is supplied, a two-way update will hold.
+If `initial` is false, `dest` will only be updated to `src`'s modified value
+when `src` next updates, otherwise (if `initial` is true) both `dest` and `src`
+will take the respective's modiefied values immediately. Note that currently 
+this can not be `unbind!`. Also note that for a two-way bind, a false initial
+is impossible.
+"""
+function bind!(dest::Signal, src2dest::Function, src::Signal, dest2src = nothing; initial = true)
+    dest2 = map(src2dest, src)
+    bind!(dest, dest2, false, initial = initial)
+    if dest2src ≠ nothing
+        src2 = map(dest2src, dest)
+        bind!(src2, src, true, initial = initial)
+    end
+end
+
+"""
     `unbind!(dest, src, twoway=true)`
 
 remove a link set up using `bind!`

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -298,6 +298,62 @@ facts("Basic checks") do
         @fact value(d) --> 4*3
         @fact value(a) --> 4*3
         @fact value(b) --> 2*4*3
+
+        # check all the modified binds
+        src = Signal(false)
+        dst = Signal(false)
+        bind!(dst, !, src)
+        @fact value(dst) --> not(value(src))
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> value(src)
+
+        src = Signal(true)
+        dst = Signal(true)
+        bind!(dst, !, src, !)
+        @fact value(dst) --> not(value(src))
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> not(value(src))
+
+        src = Signal(true)
+        dst = Signal(true)
+        bind!(dst, !, src, initial=false)
+        @fact value(dst) --> value(src)
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> value(src)
+
+        # this doesn't work
+        # src = Signal(true)
+        # dst = Signal(true)
+        # bind!(dst, !, src, !, initial=false)
+        # @fact value(dst) --> value(src)
+        # push!(src, true)
+        # @fact value(src) --> not(value(dst))
+        # push!(dst, true)
+        # @fact value(dst) --> not(value(src))
+
+        src = Signal(30.0)
+        dst = Signal(sind(30.0))
+        bind!(dst, sind, src, asind)
+
+        push!(src, 0.0)
+        step()
+        @fact value(dst) --> 0
+        push!(dst, 0.5)
+        step()
+        @fact value(src) --> roughly(30)
+
     end
-    
+
 end


### PR DESCRIPTION
fixes #157
now bind! accepts a modifier that changes the updates between the src
and dst.
This coolness now works:
```julia
src = Signal(30.0)
dst = Signal(sind(30.0))
bind!(dst, sind, src, asind)

push!(src, 0.0)
@fact value(dst) --> 0
push!(dst, 0.5)
@fact value(src) --> roughly(30)
```