### PR TITLE
Pull request/abba71cc

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -16,6 +16,7 @@ export map,
        droprepeats,
        flatten,
        bind!,
+       bindmap!,
        unbind!,
        bound_srcs,
        bound_dests
@@ -369,24 +370,69 @@ function bind!(dest::Signal, src::Signal, twoway=true; initial=true)
 
 end
 
+
 """
-    `bind!(dest, src2dest, src, dest2src=nothing; initial=true)`
+    `bindmap!(dest, src, twoway=true; initial=true)`
 
 for every update to `src` also update `dest` with a modified value (using the
-function `src2dest`) and, if `dest2src` is supplied, a two-way update will hold.
+function `src2dest`) and, if `dest2src` is specified, a two-way update will hold.
 If `initial` is false, `dest` will only be updated to `src`'s modified value
 when `src` next updates, otherwise (if `initial` is true) both `dest` and `src`
-will take the respective's modiefied values immediately. Note that currently 
-this can not be `unbind!`. Also note that for a two-way bind, a false initial
-is impossible.
+will take their respective modified values immediately. 
 """
-function bind!(dest::Signal, src2dest::Function, src::Signal, dest2src = nothing; initial = true)
-    dest2 = map(src2dest, src)
-    bind!(dest, dest2, false, initial = initial)
-    if dest2src ≠ nothing
-        src2 = map(dest2src, dest)
-        bind!(src2, src, true, initial = initial)
+function bindmap!(dest::Signal, src2dest::Function, src::Signal, dest2src::Function = identity; initial = true)
+    twoway = dest2src ≠ identity
+    if haskey(_bindings, src=>dest)
+        # subsequent bind!(dest, src) after initial should be a no-op
+        # though we should allow a change in preference for twoway bind.
+        if twoway
+            bindmap!(src, dest2src, dest, initial = initial)
+        end
+        return
     end
+
+    # We don't set src as a parent of dest, since a
+    # two-way bind would technically introduce a cycle into the signal graph,
+    # and I suppose we'd prefer not to have that. Instead we just set dest as
+    # active when src updates, which will allow its downstream actions to run.
+
+    ordered_pair = src.id < dest.id ? src=>dest : dest=>src # ordered by id
+    twoway && (_active_binds[ordered_pair] = false)
+    # the binder action comes after dest, so dest's downstream actions
+    # won't run unless we arrange it.
+    function bind_updater(srcval)
+        if !haskey(_bindings, src=>dest)
+            # will happen if has been unbound but node not gc'd
+            return
+        end
+        is_twoway = haskey(_active_binds, ordered_pair)
+        if is_twoway && _active_binds[ordered_pair]
+            # The _active_binds flag stops the (infinite) cycle of src
+            # updating dest updating src ... in the case of a two-way bind
+            _active_binds[ordered_pair] = false
+        else
+            is_twoway && (_active_binds[ordered_pair] = true)
+            # we "pause" the current push!, simulate a push! to dest with
+            # run_push then resume processing the original push by reactivating
+            # the previously active nodes.
+            active_nodes = pause_push()
+            # `true` below is for dont_remove_dead nodes - messes with active_nodes
+            # TODO - check that - not sure it actually does, this may be a relic
+            # of an earlier implementation which used the node's id's
+            run_push(dest, src2dest(src.value), onerror_rethrow, true) # here is the only place where we implement the modifying function!
+            foreach(activate!, active_nodes)
+        end
+        nothing
+    end
+    finalizer(src, (src)->unbindmap!(dest, src, twoway))
+
+    _bindings[src=>dest] = map(bind_updater, src; name="binder: $(src.name)=>$(dest.name)")
+    initial && bind_updater(src.value) # init now that _bindings[src=>dest] is set
+
+    if twoway
+        bindmap!(src, dest2src, dest, initial = initial)
+    end
+
 end
 
 """

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -370,6 +370,26 @@ function bind!(dest::Signal, src::Signal, twoway=true; initial=true)
 end
 
 """
+    `bind!(dest, src2dest, src, dest2src=nothing; initial=true)`
+
+for every update to `src` also update `dest` with a modified value (using the
+function `src2dest`) and, if `dest2src` is supplied, a two-way update will hold.
+If `initial` is false, `dest` will only be updated to `src`'s modified value
+when `src` next updates, otherwise (if `initial` is true) both `dest` and `src`
+will take the respective's modiefied values immediately. Note that currently 
+this can not be `unbind!`. Also note that for a two-way bind, a false initial
+is impossible.
+"""
+function bind!(dest::Signal, src2dest::Function, src::Signal, dest2src = nothing; initial = true)
+    dest2 = map(src2dest, src)
+    bind!(dest, dest2, false, initial = initial)
+    if dest2src ≠ nothing
+        src2 = map(dest2src, dest)
+        bind!(src2, src, true, initial = initial)
+    end
+end
+
+"""
     `unbind!(dest, src, twoway=true)`
 
 remove a link set up using `bind!`

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -424,7 +424,7 @@ function bindmap!(dest::Signal, src2dest::Function, src::Signal, dest2src::Funct
         end
         nothing
     end
-    finalizer(src, (src)->unbindmap!(dest, src, twoway))
+    finalizer(src, (src)->unbind!(dest, src, twoway))
 
     _bindings[src=>dest] = map(bind_updater, src; name="binder: $(src.name)=>$(dest.name)")
     initial && bind_updater(src.value) # init now that _bindings[src=>dest] is set

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -298,6 +298,62 @@ facts("Basic checks") do
         @fact value(d) --> 4*3
         @fact value(a) --> 4*3
         @fact value(b) --> 2*4*3
+
+        # check all the modified binds
+        src = Signal(false)
+        dst = Signal(false)
+        bind!(dst, !, src)
+        @fact value(dst) --> not(value(src))
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> value(src)
+
+        src = Signal(true)
+        dst = Signal(true)
+        bind!(dst, !, src, !)
+        @fact value(dst) --> not(value(src))
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> not(value(src))
+
+        src = Signal(true)
+        dst = Signal(true)
+        bind!(dst, !, src, initial=false)
+        @fact value(dst) --> value(src)
+        push!(src, true)
+        step()
+        @fact value(src) --> not(value(dst))
+        push!(dst, true)
+        step()
+        @fact value(dst) --> value(src)
+
+        # this doesn't work
+        # src = Signal(true)
+        # dst = Signal(true)
+        # bind!(dst, !, src, !, initial=false)
+        # @fact value(dst) --> value(src)
+        # push!(src, true)
+        # @fact value(src) --> not(value(dst))
+        # push!(dst, true)
+        # @fact value(dst) --> not(value(src))
+
+        src = Signal(30.0)
+        dst = Signal(sind(30.0))
+        bind!(dst, sind, src, asind)
+
+        push!(src, 0.0)
+        step()
+        @fact value(dst) --> 0
+        push!(dst, 0.5)
+        step()
+        @fact value(src) --> roughly(30)
+
     end
-    
+
 end


### PR DESCRIPTION
Yea, I forgot to fix the docstring.. 
I figured that `dest2src = nothing` is simpler and makes more sense so no `like_identity` is needed. The default behavior of `bind!` for `twoway` results in `dest2src = identity` anyhow so in practice that's what happens except when the user wants to modify the binded map in a specific way. 