### PR TITLE
Support IOContext flags in show

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -142,7 +142,9 @@ end
 
 function Base.show(io::IO, n::Signal)
     active_str = isactive(n) ? "(active)" : ""
-    write(io, "$(n.id): \"$(n.name)\" = $(something(n.value, "nothing")) $(eltype(n)) $active_str")
+    print(io, n.id, ": \"", n.name, "\" = ")
+    print(io, something(n.value, "nothing"))
+    print(io, ' ', eltype(n), ' ', active_str)
 end
 
 value(n) = n


### PR DESCRIPTION
`write` is low-level and ignores IOContext flags. For array signals this can make a big difference (this example uses Revise and the `git stash pop` switches to the code in this PR):

```julia
julia> using Reactive

julia> s = Signal(rand(1000,1000,20));

julia> io = IOContext(IOBuffer(), :compact=>true, :limit=>true)
IOContext(IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1))

julia> @time show(io, s)
  5.515413 seconds (704.58 k allocations: 511.058 MiB, 5.64% gc time)
180014439

julia> io = IOContext(IOBuffer(), :compact=>true, :limit=>true)
IOContext(IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1))

julia> @time show(io, s)
  5.127384 seconds (4.27 k allocations: 475.867 MiB, 3.04% gc time)
180014439

shell> git stash pop
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   src/core.jl

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (f2783cf4c846f0cab5bdd7c3cd2304ba674113b5)

julia> io = IOContext(IOBuffer(), :compact=>true, :limit=>true)
IOContext(IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1))

julia> @time show(io, s)
  0.136538 seconds (140.68 k allocations: 7.182 MiB)

julia> io = IOContext(IOBuffer(), :compact=>true, :limit=>true)
IOContext(IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1))

julia> @time show(io, s)
  0.000204 seconds (178 allocations: 8.125 KiB)
```


Fixes https://github.com/JuliaImages/ImageView.jl/issues/161